### PR TITLE
Lpff bug fix

### DIFF
--- a/playgrounds/ivtExt/src/main/java/playground/clruch/dispatcher/LPFeedforwardDispatcher.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/dispatcher/LPFeedforwardDispatcher.java
@@ -134,9 +134,8 @@ public class LPFeedforwardDispatcher extends PartitionedDispatcher {
 
             // consistency check: rebalancing destination links must not exceed
             // available vehicles in virtual node
-            Map<VirtualNode, List<VehicleLinkPair>> finalAvailableVehicles = availableVehicles;
             GlobalAssert.that(!virtualNetwork.getVirtualNodes().stream()
-                    .filter(v -> finalAvailableVehicles.get(v).size() < destinationLinks.get(v).size()).findAny().isPresent());
+                    .filter(v -> availableVehicles.get(v).size() < destinationLinks.get(v).size()).findAny().isPresent());
 
             // send rebalancing vehicles using the setVehicleRebalance command
             for (VirtualNode virtualNode : destinationLinks.keySet()) {

--- a/playgrounds/ivtExt/src/main/java/playground/clruch/traveldata/TravelData.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/traveldata/TravelData.java
@@ -181,8 +181,8 @@ public class TravelData implements Serializable {
             // accuracy)
             for (int i = 0; i < Dimensions.of(rebalancingRate).get(0); ++i) {
                 for (int j = 0; j < Dimensions.of(rebalancingRate).get(1); ++j) {
-                    if (rebalancingRate.Get(i, j).number().doubleValue() < 0) {
-                        GlobalAssert.that(rebalancingRate.Get(i, j).number().doubleValue() > 10E-7);
+                    if (rebalancingRate.Get(i, j).number().doubleValue() < 0.0) {
+                        GlobalAssert.that(rebalancingRate.Get(i, j).number().doubleValue() > -10E-7);
                         rebalancingRate.set(RealScalar.of(0.0), i, j);
                     }
                 }

--- a/playgrounds/ivtExt/src/main/java/playground/clruch/traveldata/TravelData.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/traveldata/TravelData.java
@@ -176,7 +176,22 @@ public class TravelData implements Serializable {
 
             // ensure positivity of solution (small negative values possible due to solver
             // accuracy)
-            rebalancingRate.flatten(-1).forEach(v -> GlobalAssert.that(v.Get().number().doubleValue() > -10E-7));
+            
+            // ensure positivity of solution (small negative values possible due to solver
+            // accuracy)
+            for (int i = 0; i < Dimensions.of(rebalancingRate).get(0); ++i) {
+                for (int j = 0; j < Dimensions.of(rebalancingRate).get(1); ++j) {
+                    if (rebalancingRate.Get(i, j).number().doubleValue() < 0) {
+                        GlobalAssert.that(rebalancingRate.Get(i, j).number().doubleValue() > 10E-7);
+                        rebalancingRate.set(RealScalar.of(0.0), i, j);
+                    }
+                }
+            }
+
+            // rebalancingRate.flatten(-1).forEach(v -> GlobalAssert.that(v.Get().number().doubleValue() > -10E-7));
+            
+            
+            
 
             alphaijPSF.set(rebalancingRate, t);
 


### PR DESCRIPTION
The small negative numbers due to numeric errors in the solvers caused negative rebalancing entries in LPFFDispatcher when adding up for too long. 