### PR TITLE
Update to av:0.1.3

### DIFF
--- a/playgrounds/ivtExt/pom.xml
+++ b/playgrounds/ivtExt/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>ch.ethz.matsim</groupId>
 			<artifactId>av</artifactId>
-			<version>0.1.2-nov17</version>
+			<version>0.1.3-nov17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim</groupId>

--- a/playgrounds/ivtExt/src/main/java/playground/clruch/router/FuturePathContainer.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/router/FuturePathContainer.java
@@ -1,13 +1,16 @@
 // code by jph
 package playground.clruch.router;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 
 import ch.ethz.idsc.queuey.util.GlobalAssert;
-import ch.ethz.matsim.av.plcpc.LeastCostPathFuture;
 import playground.clruch.utils.VrpPathUtils;
 
 /**
@@ -21,12 +24,12 @@ public final class FuturePathContainer {
     private final Link startLink;
     private final Link destLink;
     private final double startTime;
-    private final LeastCostPathFuture leastCostPathFuture;
+    private final Future<Path> leastCostPathFuture;
 
     private final TravelTime travelTime; // reference for convenience
     private VrpPathWithTravelData vrpPathWithTravelData = null; // <- always private!
 
-    FuturePathContainer(Link startLink, Link destLink, double startTime, LeastCostPathFuture leastCostPathFuture, TravelTime travelTime) {
+    FuturePathContainer(Link startLink, Link destLink, double startTime, Future<Path> leastCostPathFuture, TravelTime travelTime) {
         this.startLink = startLink;
         this.destLink = destLink;
         this.startTime = startTime;
@@ -45,16 +48,13 @@ public final class FuturePathContainer {
         return vrpPathWithTravelData;
     }
 
-    private static VrpPathWithTravelData getRouteBlocking(Link startLink, Link destLink, double startTime, LeastCostPathFuture leastCostPathFuture, TravelTime travelTime) {
-        try {
-            Thread.sleep(0, 100000);
-            while (!leastCostPathFuture.isDone())
-                Thread.sleep(0, 100000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+    private static VrpPathWithTravelData getRouteBlocking(Link startLink, Link destLink, double startTime, Future<Path> leastCostPathFuture, TravelTime travelTime) {
+    	try {
+            VrpPathWithTravelData vrpPathWithTravelData = VrpPaths.createPath(startLink, destLink, startTime, leastCostPathFuture.get(), travelTime);
+            GlobalAssert.that(VrpPathUtils.isConsistent(vrpPathWithTravelData));
+            return vrpPathWithTravelData;
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
-        VrpPathWithTravelData vrpPathWithTravelData = VrpPaths.createPath(startLink, destLink, startTime, leastCostPathFuture.get(), travelTime);
-        GlobalAssert.that(VrpPathUtils.isConsistent(vrpPathWithTravelData));
-        return vrpPathWithTravelData;
     }
 }

--- a/playgrounds/ivtExt/src/main/java/playground/clruch/router/FuturePathFactory.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/router/FuturePathFactory.java
@@ -1,10 +1,12 @@
 // code by jph
 package playground.clruch.router;
 
+import java.util.concurrent.Future;
+
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 
-import ch.ethz.matsim.av.plcpc.LeastCostPathFuture;
 import ch.ethz.matsim.av.plcpc.ParallelLeastCostPathCalculator;
 
 /**
@@ -22,7 +24,7 @@ public class FuturePathFactory {
     }
 
     public FuturePathContainer createFuturePathContainer(Link startLink, Link destLink, double startTime) {
-        LeastCostPathFuture leastCostPathFuture = parallelLeastCostPathCalculator.calcLeastCostPath( // <- non-blocking call
+        Future<Path> leastCostPathFuture = parallelLeastCostPathCalculator.calcLeastCostPath( // <- non-blocking call
                 startLink.getToNode(), destLink.getFromNode(), startTime, null, null);
         return new FuturePathContainer(startLink, destLink, startTime, leastCostPathFuture, travelTime);
     }

--- a/playgrounds/ivtExt/src/main/java/playground/clruch/router/InstantPathFactory.java
+++ b/playgrounds/ivtExt/src/main/java/playground/clruch/router/InstantPathFactory.java
@@ -1,11 +1,13 @@
 // code by jph
 package playground.clruch.router;
 
+import java.util.concurrent.Future;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 
-import ch.ethz.matsim.av.plcpc.LeastCostPathFuture;
 import ch.ethz.matsim.av.plcpc.ParallelLeastCostPathCalculator;
 
 public class InstantPathFactory {
@@ -20,7 +22,7 @@ public class InstantPathFactory {
     }
 
     public VrpPathWithTravelData getVrpPathWithTravelData(Link startLink, Link destLink, double startTime) {
-        LeastCostPathFuture leastCostPathFuture = parallelLeastCostPathCalculator.calcLeastCostPath( // <- non-blocking call
+        Future<Path> leastCostPathFuture = parallelLeastCostPathCalculator.calcLeastCostPath( // <- non-blocking call
                 startLink.getToNode(), destLink.getFromNode(), startTime, null, null);
         return new FuturePathContainer(startLink, destLink, startTime, leastCostPathFuture, travelTime).getVrpPathWithTravelData();
     }


### PR DESCRIPTION
Updates the dependency on `ch.eth.matsim.av` to `0.1.3-nov17`. This includes some minor fixes in the av package, but also a complete rewrite of the parallel routing component. It is now much simpler and straightforward code- and construction-wise.
Furthermore, AVs have an infinite lifetime now by default, hence former exceptions of "schedule is COMPLETED" etc. are gone now.
Also, when revising the code I had the feeling that the old implementation of the parallel router would actually delay the computation by *several* simulation steps, and not only one. There is no `LeastCostPathFuture` anymore, but only a more standard-compliant `Future<Path>`.